### PR TITLE
Update model.v.5.0.txt

### DIFF
--- a/WebAPP/SOLVERs/model.v.5.0.txt
+++ b/WebAPP/SOLVERs/model.v.5.0.txt
@@ -21,8 +21,8 @@ set MODExTECHNOLOGYperFUELout{COMMODITY} within MODE_OF_OPERATION cross TECHNOLO
 set MODExTECHNOLOGYperFUELin{COMMODITY} within MODE_OF_OPERATION cross TECHNOLOGY;
 set MODExTECHNOLOGYperSTORAGEto{STORAGE} within MODE_OF_OPERATION cross TECHNOLOGY;
 set MODExTECHNOLOGYperSTORAGEfrom{STORAGE} within MODE_OF_OPERATION cross TECHNOLOGY;
-set MODExTECHNOLOGYperEMISSION{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY;
-set MODExTECHNOLOGYperEMISSIONChange{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY;
+set MODExTECHNOLOGYperEMISSION{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY := {m in MODE_OF_OPERATION, t in TECHNOLOGY: exists{r in REGION, y in YEAR} (EmissionToActivityChangeRatio[r,t,e,m,y] <> 0 or EmissionActivityRatio[r,t,e,m,y] <> 0)};
+set MODExTECHNOLOGYperEMISSIONChange{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY := {m in MODE_OF_OPERATION, t in TECHNOLOGY : exists{r in REGION, y in YEAR} (EmissionToActivityChangeRatio[r,t,e,m,y] <> 0 or EmissionActivityRatio[r,t,e,m,y] <> 0)};
 #
 #####################
 #    Parameters     #


### PR DESCRIPTION
The original supersets:` set MODExTECHNOLOGYperEMISSION{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY;` and
`set MODExTECHNOLOGYperEMISSIONChange{e in EMISSION} within MODE_OF_OPERATION cross TECHNOLOGY;` generates empty supersets _no value for MODExTECHNOLOGYperEMISSIONChange[CO2eq]_

In the original formulation, the supersets function correctly only when both `EmissionToActivityChangeRatio` and` EmissionActivityRatio `are defined for the same emission (e.g., CO2eq). If `EmissionToActivityChangeRatio` is instead defined for a different emission (e.g., CO2_land) that does not appear in EmissionActivityRatio, an error will occur due to an empty superset—specifically: "_empty supersets no value._"