### PR TITLE
Skip non-directory entries in cleanUp results folder

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -972,6 +972,8 @@ class DataFile(Osemosys):
 
             for caserunname in os.listdir( self.resultsPath):
                 caserunname_path = os.path.join(self.resultsPath, caserunname)
+                if not os.path.isdir(caserunname_path):
+                    continue
                 for carerunData in os.listdir( caserunname_path):
                     file_path = os.path.join(caserunname_path, carerunData)
                     try:


### PR DESCRIPTION
Fixes #7

  - Skip non-directory entries when iterating over the results folder during cleanUp(). Not an issue on Windows but a good patch to prevent errors on any future platforms.

  Why
  - On macOS, Finder creates .DS_Store files in folders.
  - cleanUp() assumes every entry in res/ is a directory and crashes with NotADirectoryError when it hits .DS_Store.
  - This guard avoids the error without changing any behavior on other platforms.

  Testing
  - Clicked CLEAN UP on macOS; no 500 error.