### PR TITLE
Migrate solver execution logging in DataFileClass.run() from print() to logging

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -7,6 +7,13 @@ from flask_cors import CORS
 from datetime import timedelta
 # from pathlib import Path
 
+import logging
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s: %(message)s"
+    )
+
 #import json
 from Classes.Base import Config
 # from API.Classes.Base.SyncS3 import SyncS3


### PR DESCRIPTION
# Refactor: Migrate Solver Execution Logging to Python `logging` 🪵

**Closes:** #14

##  Overview
This PR replaces legacy `print()` statements within the `DataFileClass.run()` method with Python’s native `logging` module. 

As the project evolves toward cross-platform support and more complex solver workflows, transitioning from unformatted stdout to structured logging is essential for professional debugging, maintainability, and future-proofing.

---

##  Changes

### 1. Structured Logging in `DataFileClass`
* **Informational Logs:** Replaced timing and progress `print()` calls with `logger.info()`.
* **Enhanced Error Handling:** Replaced standard `print(ex)` with `logger.error(..., exc_info=True)`. This captures the full stack trace in the server logs while maintaining a clean output for the end-user.
* **Contextual Metadata:** Console logs now automatically include:
    * ISO-8601 Timestamps
    * Module/Logger Name (`DataFileClass`)
    * Log Severity Level (INFO, ERROR, etc.)

### 2. Centralized Configuration
Introduced a standardized logging configuration in `API/app.py`:

```python
logging.basicConfig(
    level=logging.INFO,
    format="%(asctime)s [%(name)s] %(levelname)s: %(message)s"
)

---