### PR TITLE
fix: move hardcoded SECRET_KEY to environment variable via python-dotenv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# MUIO Environment Variables — copy this file to .env and fill in the values
+# NEVER commit the .env file to version control
+
+# -------------------------------------------------------------------
+# Flask Security (REQUIRED)
+# Generate a strong key with: python -c "import secrets; print(secrets.token_hex(32))"
+# -------------------------------------------------------------------
+SECRET_KEY=your-strong-random-secret-key-here
+
+# -------------------------------------------------------------------
+# Server Configuration (optional — defaults shown)
+# -------------------------------------------------------------------
+PORT=5002
+
+# -------------------------------------------------------------------
+# Deployment Mode
+# Set to 0 for local/Windows, 1 for Heroku/cloud
+# -------------------------------------------------------------------
+HEROKU_DEPLOY=0
+
+# -------------------------------------------------------------------
+# AWS S3 Sync (optional — leave blank to disable cloud sync)
+# -------------------------------------------------------------------
+AWS_SYNC=0
+S3_BUCKET=
+S3_KEY=
+S3_SECRET=

--- a/API/app.py
+++ b/API/app.py
@@ -1,6 +1,9 @@
 #import sys
 import os
 import sys
+from dotenv import load_dotenv
+
+load_dotenv()  # loads variables from .env into os.environ
 
 from flask import Flask, jsonify, request, session, render_template
 from flask_cors import CORS
@@ -42,7 +45,7 @@ print(__name__)
 app = Flask(__name__, static_url_path='', static_folder=static_dir,  template_folder=template_dir)
 
 app.permanent_session_lifetime = timedelta(days=5)
-app.config['SECRET_KEY'] = '12345'
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'INSECURE-DEV-KEY-CHANGE-ME')
 app.config["MAX_CONTENT_LENGTH"] = None
 
 app.register_blueprint(upload_api)


### PR DESCRIPTION
- Add load_dotenv() call to API/app.py to read from .env file
- Replace hardcoded SECRET_KEY '12345' with os.environ.get()
- Add .env.example template with all configurable variables
- python-dotenv was already a listed dependency (requirements.txt)

Fixes #25