### PR TITLE
fix: preserve exception context and return structured error responses

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -92,10 +92,10 @@ def copy():
                 "status_code": "success"
             }
         return(response)
-    except(IOError):
-        raise IOError
-    except OSError:
-        raise OSError
+    except(IOError) as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
+    except OSError as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
 
 @case_api.route("/deleteCase", methods=['POST'])
 def deleteCase():
@@ -119,8 +119,8 @@ def deleteCase():
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
-    except OSError:
-        raise OSError
+    except OSError as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
 
 @case_api.route("/getResultData", methods=['POST'])
 def getResultData():

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -240,8 +240,8 @@ def backupCase():
 
     except(IOError):
         return jsonify('No existing cases!'), 404
-    except OSError:
-        raise OSError
+    except OSError as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
 
 @upload_api.route('/uploadCaseUnchunked_old', methods=['POST'])
 def uploadCaseUnchunked_old():
@@ -402,10 +402,10 @@ def uploadCaseUnchunked_old():
         }
 
         return jsonify(response), 200
-    except(IOError):
-        raise IOError
-    except OSError:
-        raise OSError
+    except(IOError) as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
+    except OSError as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
 
 def handle_full_zip(file, filepath=None):
     msg = []
@@ -649,7 +649,7 @@ def uploadXls():
         }
 
         return jsonify(response), 200
-    except(IOError):
-        raise IOError
-    except OSError:
-        raise OSError
+    except(IOError) as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500
+    except OSError as e:
+        return jsonify({"error": str(e), "type": type(e).__name__}), 500


### PR DESCRIPTION
### Fix: Preserve exception context and return consistent API error responses

This PR fixes incorrect exception re-raising in several routes where `raise IOError` / `raise OSError` was used inside `except` blocks.

Using `raise IOError` creates a new empty exception, which discards the original error message and traceback. As a result, when failures occur the API returns a generic 500 error with little or no debugging information.

---

## Problem

The previous pattern:
```python
except IOError:
    raise IOError
```

replaces the original exception instead of propagating it. This removes important context such as the file path, system error message, and traceback, making debugging difficult and producing unclear API responses.

---

## Changes

- Replaced incorrect exception re-raises with structured error handling:
```python
except IOError as e:
    return jsonify({
        "error": str(e),
        "type": type(e).__name__
    }), 500
```

- Applied consistently across affected locations in:
  - `CaseRoute.py`
  - `UploadRoute.py`

---

## Result

- Original exception details are preserved
- API responses now contain meaningful error information
- Debugging server-side failures becomes significantly easier
- Prevents silent loss of exception context

---