### PR TITLE
fix: remove invalid MathJax linebreaks config causing console warning

### DIFF
--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -48,8 +48,7 @@
 					inlineMath: [['\\(','\\)']],
 					displayMath: [['$$','$$']],
 					processEscapes: true,
-					processEnvironments: true,
-					linebreaks: { automatic: true }  // dozvoli automatske prijelome
+					processEnvironments: true,		
 				}
 			};
 		</script>


### PR DESCRIPTION
This PR removes an invalid MathJax configuration option (`linebreaks`) from the `tex` block in index.html.
In MathJax v3, the `linebreaks` option is not valid inside the `tex` configuration, which causes the warning:
**"MathJax: Invalid option 'linebreaks'"**

The previous configuration appears to be intended for an older MathJax version. Removing this option eliminates the console warning and aligns the configuration with MathJax v3.

No functional changes to the UI.